### PR TITLE
Add missing copyright and year line to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+Copyright (c) 2007-2023 Ryan Vogt <rvogt@ualberta.ca>
+
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above
 copyright notice and this permission notice appear in all copies.


### PR DESCRIPTION
The copyright/year line was in README.md, but got missed in LICENSE.