### PR TITLE
Make Java 'ant debug' run with '-Xlint:all'

### DIFF
--- a/java/build.xml
+++ b/java/build.xml
@@ -20,7 +20,7 @@
     <property name="outputDir" value="./class/" />
     <property name="javadocDir" value="./javadoc/" />
     <property name="liboutDir" value="./libout/" />
-    <property name="libFile" value="dbs3-1.2.0.jar" />
+    <property name="libFile" value="dbs3-1.2.1.jar" />
   </target>
   <target name="compile" depends="init">
     <depend srcdir="${sourceDir}" destDir="${outputDir}" />
@@ -33,8 +33,7 @@
     <depend srcdir="${sourceDir}" destDir="${outputDir}" />
     <javac srcdir="${sourceDir}" destDir="${outputDir}" debug="on"
            includeantruntime="false">
-      <compilerarg value="-Xlint:unchecked" />
-      <compilerarg value="-Xlint:deprecation" />
+      <compilerarg value="-Xlint:all" />
       <compilerarg value="--release=9" />
     </javac>
   </target>

--- a/java/src/ca/ualberta/dbs3/cartography/MapFileException.java
+++ b/java/src/ca/ualberta/dbs3/cartography/MapFileException.java
@@ -24,6 +24,11 @@ import ca.ualberta.dbs3.commandLine.InputFileException;
  */
 public class MapFileException extends InputFileException {
     /**
+     * Unused serialization version UID.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
      * Creates a new <code>MapFileException</code> with the given error having
      * happened in the given file.
      *

--- a/java/src/ca/ualberta/dbs3/client/Client.java
+++ b/java/src/ca/ualberta/dbs3/client/Client.java
@@ -841,5 +841,15 @@ public abstract class Client {
             }
             return false;
         }
+
+        /**
+         * Returns a hash code for this <code>UAMPUpdate</code>.
+         *
+         * @return a hash code for this <code>UAMPUpdate</code>, equal to the
+         *         hash code of its x coordinate.
+         */
+        public int hashCode() {
+            return this.x.hashCode();
+        }
     }
 }

--- a/java/src/ca/ualberta/dbs3/commandLine/InputFileException.java
+++ b/java/src/ca/ualberta/dbs3/commandLine/InputFileException.java
@@ -24,6 +24,11 @@ import java.io.*;
  */
 public class InputFileException extends Exception {
     /**
+     * Unused serialization version UID.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
      * Creates a new <code>InputFileException</code> with the given error
      * having happened in the given file.
      *

--- a/java/src/ca/ualberta/dbs3/commandLine/ParseException.java
+++ b/java/src/ca/ualberta/dbs3/commandLine/ParseException.java
@@ -22,6 +22,11 @@ package ca.ualberta.dbs3.commandLine;
  */
 public class ParseException extends Exception {
     /**
+     * Unused serialization version UID.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
      * Creates a new <code>ParseException</code> with the given message.
      *
      * @param message the detail message.

--- a/java/src/ca/ualberta/dbs3/gui/ColourDialog.java
+++ b/java/src/ca/ualberta/dbs3/gui/ColourDialog.java
@@ -30,6 +30,11 @@ public class ColourDialog extends DialogUserInput {
     private static final int PREVIEW_SIZE = 50;
 
     /**
+     * Unused serialization version UID.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
      * The red text field.
      */
     private UserIntegerField red;
@@ -168,6 +173,11 @@ public class ColourDialog extends DialogUserInput {
      * preview of the input colour to the user.
      */
     private class PreviewSwatch extends JPanel {
+        /**
+         * Unused serialization version UID.
+         */
+        private static final long serialVersionUID = 1L;
+
         /**
          * Paints the desired colour.
          */

--- a/java/src/ca/ualberta/dbs3/gui/ColourMenuItem.java
+++ b/java/src/ca/ualberta/dbs3/gui/ColourMenuItem.java
@@ -34,6 +34,11 @@ public abstract class ColourMenuItem extends JMenuItem {
     private static final int ICON_SIZE = 16;
 
     /**
+     * Unused serialization version UID.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
      * The parent window over which we should display the dialog box.
      */
     private MainFrame parent;

--- a/java/src/ca/ualberta/dbs3/gui/DialogCancellable.java
+++ b/java/src/ca/ualberta/dbs3/gui/DialogCancellable.java
@@ -29,6 +29,11 @@ import javax.swing.*;
  */
 public abstract class DialogCancellable extends JDialog {
     /**
+     * Unused serialization version UID.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
      * The owner frame or dialog.
      */
     private Window owner;
@@ -200,6 +205,11 @@ public abstract class DialogCancellable extends JDialog {
      * subclass cancellation actions and disposing of the dialog.
      */
     private class EscapeKeyAction extends AbstractAction {
+        /**
+         * Unused serialization version UID.
+         */
+        private static final long serialVersionUID = 1L;
+
         /**
          * Called when the user presses the escape key.
          *

--- a/java/src/ca/ualberta/dbs3/gui/DialogOwner.java
+++ b/java/src/ca/ualberta/dbs3/gui/DialogOwner.java
@@ -26,6 +26,11 @@ import javax.swing.*;
  */
 public class DialogOwner extends JFrame {
     /**
+     * Unused serialization version UID.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
      * The linked list of all dialogs owned by this frame, with elements at the
      * front of the list having had focus more recently.
      */

--- a/java/src/ca/ualberta/dbs3/gui/DialogUserInput.java
+++ b/java/src/ca/ualberta/dbs3/gui/DialogUserInput.java
@@ -31,6 +31,11 @@ import javax.swing.event.*;
  */
 public abstract class DialogUserInput extends DialogCancellable {
     /**
+     * Unused serialization version UID.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
      * The OK button.
      */
     private JButton okButton;
@@ -235,6 +240,11 @@ public abstract class DialogUserInput extends DialogCancellable {
      * not be enabled).
      */
     private class EnterKeyAction extends AbstractAction {
+        /**
+         * Unused serialization version UID.
+         */
+        private static final long serialVersionUID = 1L;
+
         /**
          * Translates a press of the enter key into a click of the OK button.
          *

--- a/java/src/ca/ualberta/dbs3/gui/FileSaver.java
+++ b/java/src/ca/ualberta/dbs3/gui/FileSaver.java
@@ -116,6 +116,11 @@ public class FileSaver {
      */
     private class ConfirmChooser extends JFileChooser {
         /**
+         * Unused serialization version UID.
+         */
+        private static final long serialVersionUID = 1L;
+
+        /**
          * Creates a new <code>ConfirmChooser</code> starting in the given
          * directory.
          *

--- a/java/src/ca/ualberta/dbs3/gui/MainFrame.java
+++ b/java/src/ca/ualberta/dbs3/gui/MainFrame.java
@@ -56,6 +56,11 @@ public class MainFrame extends DialogOwner {
     private static final int COLOUR_SEPARATOR_INDEX = 3;
 
     /**
+     * Unused serialization version UID.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
      * The DBS3 map file opened in this window.
      */
     private String filename;
@@ -676,6 +681,11 @@ public class MainFrame extends DialogOwner {
      */
     private class StreetColourItem extends ColourMenuItem {
         /**
+         * Unused serialization version UID.
+         */
+        private static final long serialVersionUID = 1L;
+
+        /**
          * Creates a new <code>StreetColourItem</code>.
          */
         public StreetColourItem() {
@@ -708,6 +718,11 @@ public class MainFrame extends DialogOwner {
      * displaying a menu item and dialog for changing the intersection colour.
      */
     private class IntersectionColourItem extends ColourMenuItem {
+        /**
+         * Unused serialization version UID.
+         */
+        private static final long serialVersionUID = 1L;
+
         /**
          * Creates a new <code>IntersectionColourItem</code>.
          */
@@ -743,6 +758,11 @@ public class MainFrame extends DialogOwner {
      */
     private class DestinationColourItem extends ColourMenuItem {
         /**
+         * Unused serialization version UID.
+         */
+        private static final long serialVersionUID = 1L;
+
+        /**
          * Creates a new <code>DestinationColourItem</code>.
          */
         public DestinationColourItem() {
@@ -776,6 +796,11 @@ public class MainFrame extends DialogOwner {
      * menu item and dialog for changing the colour of agents in a given state.
      */
     private class StateColourItem extends ColourMenuItem {
+        /**
+         * Unused serialization version UID.
+         */
+        private static final long serialVersionUID = 1L;
+
         /**
          * The state being controlled by this menu item.
          */
@@ -821,6 +846,11 @@ public class MainFrame extends DialogOwner {
      * keyboard input.
      */
     private class GroupIndexAction extends AbstractAction {
+        /**
+         * Unused serialization version UID.
+         */
+        private static final long serialVersionUID = 1L;
+
         /**
          * The menu item group to modify.
          */

--- a/java/src/ca/ualberta/dbs3/gui/MainFrameControls.java
+++ b/java/src/ca/ualberta/dbs3/gui/MainFrameControls.java
@@ -73,6 +73,11 @@ public class MainFrameControls extends JPanel {
     private static final long GRACE_MILLISECONDS = 1500;
 
     /**
+     * Unused serialization version UID.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
      * The button that returns to the beginning of the simulation.
      */
     private TimeButton beginningButton;
@@ -791,6 +796,11 @@ public class MainFrameControls extends JPanel {
      */
     private class TimeAction extends AbstractAction {
         /**
+         * Unused serialization version UID.
+         */
+        private static final long serialVersionUID = 1L;
+
+        /**
          * The amount by which to modify the time.
          */
         private long amount;
@@ -828,6 +838,11 @@ public class MainFrameControls extends JPanel {
      * button when a certain keyboard input is performed.
      */
     private class ClickAction extends AbstractAction {
+        /**
+         * Unused serialization version UID.
+         */
+        private static final long serialVersionUID = 1L;
+
         /**
          * The button to click.
          */

--- a/java/src/ca/ualberta/dbs3/gui/MainFrameImage.java
+++ b/java/src/ca/ualberta/dbs3/gui/MainFrameImage.java
@@ -32,6 +32,11 @@ import javax.swing.*;
  */
 public class MainFrameImage extends JPanel {
     /**
+     * Unused serialization version UID.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
      * The map being displayed.
      */
     private Map map;

--- a/java/src/ca/ualberta/dbs3/gui/MenuDecorated.java
+++ b/java/src/ca/ualberta/dbs3/gui/MenuDecorated.java
@@ -25,6 +25,11 @@ import javax.swing.*;
  */
 public class MenuDecorated extends JMenu {
     /**
+     * Unused serialization version UID.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
      * Creates a new <code>MenuDecorated</code> with the given text.
      *
      * @param text the text to display for the menu.

--- a/java/src/ca/ualberta/dbs3/gui/Preferences.java
+++ b/java/src/ca/ualberta/dbs3/gui/Preferences.java
@@ -157,6 +157,16 @@ public class Preferences {
     }
 
     /**
+     * Returns a hash code for this <code>Preferences</code> object.
+     *
+     * @return a hash code for this <code>Preferences</code> object, equal to
+     *         its agent size.
+     */
+    public int hashCode() {
+        return this.agentSize;
+    }
+
+    /**
      * Adds the given observer to the list of observers to be notified when the
      * preferences are modified.
      *

--- a/java/src/ca/ualberta/dbs3/gui/PreferencesFileException.java
+++ b/java/src/ca/ualberta/dbs3/gui/PreferencesFileException.java
@@ -22,6 +22,11 @@ package ca.ualberta.dbs3.gui;
  */
 public class PreferencesFileException extends Exception {
     /**
+     * Unused serialization version UID.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
      * Creates a new <code>PreferencesFileException</code> with the given
      * message.
      *

--- a/java/src/ca/ualberta/dbs3/gui/SimulationDialog.java
+++ b/java/src/ca/ualberta/dbs3/gui/SimulationDialog.java
@@ -28,6 +28,11 @@ import javax.swing.*;
  */
 public class SimulationDialog extends DialogUserInput {
     /**
+     * Unused serialization version UID.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
      * The main frame to which this simulation configuration window belongs.
      */
     private MainFrame parent;

--- a/java/src/ca/ualberta/dbs3/gui/SimulationInitDialog.java
+++ b/java/src/ca/ualberta/dbs3/gui/SimulationInitDialog.java
@@ -32,6 +32,11 @@ public class SimulationInitDialog extends DialogCancellable {
             "Waiting for simulation initialization to begin...";
 
     /**
+     * Unused serialization version UID.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
      * The simulation builder to inform if the action is cancelled.
      */
     private SimulationBuilder builder;

--- a/java/src/ca/ualberta/dbs3/gui/SizeDialog.java
+++ b/java/src/ca/ualberta/dbs3/gui/SizeDialog.java
@@ -22,6 +22,11 @@ package ca.ualberta.dbs3.gui;
  */
 public class SizeDialog extends DialogUserInput {
     /**
+     * Unused serialization version UID.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
      * The text field containing the size of agents.
      */
     private UserIntegerField size;

--- a/java/src/ca/ualberta/dbs3/gui/TimeButton.java
+++ b/java/src/ca/ualberta/dbs3/gui/TimeButton.java
@@ -28,6 +28,11 @@ import javax.swing.*;
  */
 public class TimeButton extends JButton {
     /**
+     * Unused serialization version UID.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
      * The <code>Command</code> enumeration represents the different available
      * types of {@link TimeButton}s.
      */

--- a/java/src/ca/ualberta/dbs3/gui/TimeLabel.java
+++ b/java/src/ca/ualberta/dbs3/gui/TimeLabel.java
@@ -24,6 +24,11 @@ import javax.swing.*;
  */
 public class TimeLabel extends JLabel {
     /**
+     * Unused serialization version UID.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
      * Creates a new <code>TimeLabel</code> displaying time zero.
      */
     public TimeLabel() {

--- a/java/src/ca/ualberta/dbs3/gui/TimeSlider.java
+++ b/java/src/ca/ualberta/dbs3/gui/TimeSlider.java
@@ -29,6 +29,11 @@ public class TimeSlider extends JSlider {
     private static final int MAX_SLIDER = 100000000;
 
     /**
+     * Unused serialization version UID.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
      * The maximum number of milliseconds expressible on this slider.
      */
     private long max;

--- a/java/src/ca/ualberta/dbs3/gui/UserDoubleField.java
+++ b/java/src/ca/ualberta/dbs3/gui/UserDoubleField.java
@@ -24,6 +24,11 @@ import javax.swing.text.*;
  */
 public class UserDoubleField extends UserTextField {
     /**
+     * Unused serialization version UID.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
      * Creates a new <code>UserDoubleField</code> containing the given value.
      *
      * @param initialValue the initial value the field will contain.
@@ -64,6 +69,11 @@ public class UserDoubleField extends UserTextField {
      * contain only a single non-negative floating point value.
      */
     private class DoubleDocument extends PlainDocument {
+        /**
+         * Unused serialization version UID.
+         */
+        private static final long serialVersionUID = 1L;
+
         /**
          * Inserts a string of content, if it conforms to the required floating
          * point structure.

--- a/java/src/ca/ualberta/dbs3/gui/UserEnabler.java
+++ b/java/src/ca/ualberta/dbs3/gui/UserEnabler.java
@@ -27,6 +27,11 @@ import javax.swing.*;
  */
 public class UserEnabler extends JCheckBox {
     /**
+     * Unused serialization version UID.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
      * The components that this enabler enables or disables.
      */
     private ArrayList<JComponent> components;

--- a/java/src/ca/ualberta/dbs3/gui/UserIntegerField.java
+++ b/java/src/ca/ualberta/dbs3/gui/UserIntegerField.java
@@ -24,6 +24,11 @@ import javax.swing.text.*;
  */
 public class UserIntegerField extends UserTextField {
     /**
+     * Unused serialization version UID.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
      * Creates a new <code>UserIntegerField</code> containing the given value.
      *
      * @param initialValue the initial value the field will contain.
@@ -91,6 +96,11 @@ public class UserIntegerField extends UserTextField {
      * contain only a single non-negative integer.
      */
     private class IntegerDocument extends PlainDocument {
+        /**
+         * Unused serialization version UID.
+         */
+        private static final long serialVersionUID = 1L;
+
         /**
          * Inserts a string of content, if it conforms to the required integer
          * structure.

--- a/java/src/ca/ualberta/dbs3/gui/UserTextField.java
+++ b/java/src/ca/ualberta/dbs3/gui/UserTextField.java
@@ -36,6 +36,11 @@ public class UserTextField extends JTextField {
     private static final Color BAD_INPUT = Color.RED;
 
     /**
+     * Unused serialization version UID.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
      * Whether the text is currently legal.
      */
     private boolean isLegal;

--- a/java/src/ca/ualberta/dbs3/network/UAMPException.java
+++ b/java/src/ca/ualberta/dbs3/network/UAMPException.java
@@ -23,6 +23,11 @@ package ca.ualberta.dbs3.network;
  */
 public class UAMPException extends Exception {
     /**
+     * Unused serialization version UID.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
      * Creates a new <code>UAMPException</code> with the given message.
      *
      * @param message the detail message.

--- a/java/src/ca/ualberta/dbs3/simulations/SteadyStateTest.java
+++ b/java/src/ca/ualberta/dbs3/simulations/SteadyStateTest.java
@@ -803,6 +803,11 @@ public class SteadyStateTest extends Application {
      */
     public class SteadyStateFileException extends InputFileException {
         /**
+         * Unused serialization version UID.
+         */
+        private static final long serialVersionUID = 1L;
+
+        /**
          * Creates a new <code>SteadyStateFileException</code> with the given
          * error having happened in the given file.
          *


### PR DESCRIPTION
Make the Java code's `ant debug` run with `-Xlint:all`. Because this change affected the serialization of classes, bump the version number of the compiled Java library to 1.2.1.